### PR TITLE
Updated java facet version to 11

### DIFF
--- a/bundles/org.palladiosimulator.pcmtx.profile/.settings/org.eclipse.wst.common.project.facet.core.xml
+++ b/bundles/org.palladiosimulator.pcmtx.profile/.settings/org.eclipse.wst.common.project.facet.core.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <faceted-project>
-  <installed facet="java" version="1.8"/>
+  <installed facet="java" version="11"/>
 </faceted-project>


### PR DESCRIPTION
This PR switches the Java facet version to 11. This fixes an issue when having WST installed in Eclipse.