### PR TITLE
PALLADIO-503 Remove old StoEx Parser/Serialise/Utilities

### DIFF
--- a/bundles/edu.kit.ipd.sdq.randomutils/src/edu/kit/ipd/sdq/randomutils/ManagedPDFParser.java
+++ b/bundles/edu.kit.ipd.sdq.randomutils/src/edu/kit/ipd/sdq/randomutils/ManagedPDFParser.java
@@ -1,7 +1,8 @@
 package edu.kit.ipd.sdq.randomutils;
 
+import java.text.ParseException;
+
 import org.palladiosimulator.pcm.stoex.api.StoExParser;
-import org.palladiosimulator.pcm.stoex.api.StoExParser.SyntaxErrorException;
 
 import de.uka.ipd.sdq.probfunction.ProbabilityDensityFunction;
 import de.uka.ipd.sdq.probfunction.ProbabilityMassFunction;
@@ -37,7 +38,7 @@ public final class ManagedPDFParser {
         Expression parsedStoEx;
         try {
             parsedStoEx = STOEX_PARSER.parse(s);
-        } catch (SyntaxErrorException e) {
+        } catch (ParseException e) {
             throw new StringNotPDFException(e.getMessage());
         }
 


### PR DESCRIPTION
As requested by [PALLADIO-503](https://palladio-simulator.atlassian.net/browse/PALLADIO-503), I removed the hand-written StoEx parsers, serialisers and utilities and adjusted the code that used these classes.

This PR requires PalladioSimulator/Palladio-Core-PCM#31 to be merged before it compiles.